### PR TITLE
Makes release PR include package.json and integration test folder, ru…

### DIFF
--- a/.github/workflows/deploy_master.yml
+++ b/.github/workflows/deploy_master.yml
@@ -21,9 +21,9 @@ jobs:
           yarn install
           yarn build
           echo "Copying .github directory to temp folder so we can keep gh-pages' actions up to date"
-          cp -r .github ../.github
-          echo "Copying build directory to temp folder or it will be wiped out when we checkout gh-pages actions up to date"
           mv build ../build
+          cp -r .github test-browser package.json nightwatch.conf.js ../build/
+          echo "Copying build directory to temp folder or it will be wiped out when we checkout gh-pages"
           echo "Setting environment variable COMMIT_SHA to the shortened hash of the current commit: ${GITHUB_SHA::8}"
           echo "::set-env name=COMMIT_SHA::${GITHUB_SHA::8}"
       - name: Checkout gh-pages
@@ -34,7 +34,7 @@ jobs:
         run: |
           rm -rf *
           rm -rf .github
-          mv ../.github ./
+          mv ../build/.github ./.github
           mv ../build/* ./
           echo "remix-plugin.goquorum.com" > CNAME
           echo "Deployment of quorum-remix at commit $COMMIT_SHA to remix-plugin.goquorum.com" > README.md

--- a/.github/workflows/test_alpha_remix.yml
+++ b/.github/workflows/test_alpha_remix.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: gh-pages
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/test_prod_remix.yml
+++ b/.github/workflows/test_prod_remix.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: gh-pages
       - name: Use Node.js 10.x
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
…ns cron integration tests from gh-pages branch instead of master

Our release process right now is merge completed features into master, let those features accumulate until we're happy to release, and then merge the release PR into the gh-pages branch. Our integration tests that run every day currently check out the latest version of master and run them against whatever is deployed in prod. So our tests from the latest unreleased features will be run against the current release and will fail.

This PR changes the github action that builds master and creates a release PR to include package.json, nightwatch.conf.js, and the test-browser folder. This will allow us to check out the gh-pages branch (instead of master) in the integration test actions, run yarn install, and run yarn test_chrome/firefox with the correct set of tests.