### PR TITLE
Private transactions

### DIFF
--- a/.env.local.template
+++ b/.env.local.template
@@ -7,18 +7,24 @@ RPC_SCHEME=http
 RPC_USERNAME=u0nvbueu2x
 RPC_PASSWORD=PASSWORD_HERE
 NODE_ONE_HOST=u0a5aft4j3-u0bu939ak6-rpc.us0-aws.kaleido.io
+NODE_ONE_TESSERA=u0a5aft4j3-u0bu939ak6-ptx.us0-aws.kaleido.io
 NODE_ONE_PUB_KEY=wj/d6GyPJpReu/xF+mecwR8qPAmZM73S+TzesU5y70Y=
 NODE_TWO_HOST=u0a5aft4j3-u0u5ulmm6k-rpc.us0-aws.kaleido.io
+NODE_TWO_TESSERA=u0a5aft4j3-u0u5ulmm6k-ptx.us0-aws.kaleido.io
 NODE_TWO_PUB_KEY=Cr4orZhLtEKXSu6XQVvfTDpTUTvXYVnPHuym+r92skk=
 NODE_THREE_HOST=u0a5aft4j3-u0sog5yz3u-rpc.us0-aws.kaleido.io
+NODE_THREE_TESSERA=u0a5aft4j3-u0sog5yz3u-ptx.us0-aws.kaleido.io
 NODE_THREE_PUB_KEY=MzL4UtMSfRm0dUG+X08cYj39/Sa5QFFBVWuc42YZkwg=
 
 # Alternatively, run the 7nodes example locally, and uncomment the following
 # RPC_USERNAME=
 # RPC_PASSWORD=
 # NODE_ONE_HOST=localhost:22000
+# NODE_ONE_TESSERA=localhost:9081
 # NODE_ONE_PUB_KEY=BULeR8JyUWhiuuCMU/HLA0Q5pzkYT+cHII3ZKBey3Bo=
 # NODE_TWO_HOST=localhost:22001
+# NODE_TWO_TESSERA=localhost:9082
 # NODE_TWO_PUB_KEY=QfeDAys9MPDs2XHExtc84jKGHxZg/aj52DTh0vtA3Xc=
 # NODE_THREE_HOST=localhost:22002
+# NODE_THREE_TESSERA=localhost:9083
 # NODE_THREE_PUB_KEY=1iTZde/ndBHvzhcl7V68x44Vx7pl8nwx9LqnM/AfJUg=

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,8 +37,11 @@ jobs:
           RPC_SCHEME: http
           REMIX_URL: http://remix-dev.goquorum.com
           NODE_ONE_HOST: u0a5aft4j3-u0bu939ak6-rpc.us0-aws.kaleido.io
+          NODE_ONE_TESSERA: u0a5aft4j3-u0bu939ak6-ptx.us0-aws.kaleido.io
           NODE_ONE_PUB_KEY: wj/d6GyPJpReu/xF+mecwR8qPAmZM73S+TzesU5y70Y=
           NODE_TWO_HOST: u0a5aft4j3-u0u5ulmm6k-rpc.us0-aws.kaleido.io
+          NODE_TWO_TESSERA: u0a5aft4j3-u0u5ulmm6k-ptx.us0-aws.kaleido.io
           NODE_TWO_PUB_KEY: Cr4orZhLtEKXSu6XQVvfTDpTUTvXYVnPHuym+r92skk=
           NODE_THREE_HOST: u0a5aft4j3-u0sog5yz3u-rpc.us0-aws.kaleido.io
+          NODE_THREE_TESSERA: u0a5aft4j3-u0sog5yz3u-ptx.us0-aws.kaleido.io
           NODE_THREE_PUB_KEY: MzL4UtMSfRm0dUG+X08cYj39/Sa5QFFBVWuc42YZkwg=

--- a/.github/workflows/test_alpha_remix.yml
+++ b/.github/workflows/test_alpha_remix.yml
@@ -28,10 +28,13 @@ jobs:
           RPC_SCHEME: https
           REMIX_URL: https://remix-alpha.ethereum.org
           NODE_ONE_HOST: u0a5aft4j3-u0bu939ak6-rpc.us0-aws.kaleido.io
+          NODE_ONE_TESSERA: u0a5aft4j3-u0bu939ak6-ptx.us0-aws.kaleido.io
           NODE_ONE_PUB_KEY: wj/d6GyPJpReu/xF+mecwR8qPAmZM73S+TzesU5y70Y=
           NODE_TWO_HOST: u0a5aft4j3-u0u5ulmm6k-rpc.us0-aws.kaleido.io
+          NODE_TWO_TESSERA: u0a5aft4j3-u0u5ulmm6k-ptx.us0-aws.kaleido.io
           NODE_TWO_PUB_KEY: Cr4orZhLtEKXSu6XQVvfTDpTUTvXYVnPHuym+r92skk=
           NODE_THREE_HOST: u0a5aft4j3-u0sog5yz3u-rpc.us0-aws.kaleido.io
+          NODE_THREE_TESSERA: u0a5aft4j3-u0sog5yz3u-ptx.us0-aws.kaleido.io
           NODE_THREE_PUB_KEY: MzL4UtMSfRm0dUG+X08cYj39/Sa5QFFBVWuc42YZkwg=
       - name: Make reports/screenshots available
         uses: actions/upload-artifact@v1

--- a/.github/workflows/test_prod_remix.yml
+++ b/.github/workflows/test_prod_remix.yml
@@ -31,10 +31,13 @@ jobs:
           RPC_SCHEME: https
           REMIX_URL: https://remix.ethereum.org
           NODE_ONE_HOST: u0a5aft4j3-u0bu939ak6-rpc.us0-aws.kaleido.io
+          NODE_ONE_TESSERA: u0a5aft4j3-u0bu939ak6-ptx.us0-aws.kaleido.io
           NODE_ONE_PUB_KEY: wj/d6GyPJpReu/xF+mecwR8qPAmZM73S+TzesU5y70Y=
           NODE_TWO_HOST: u0a5aft4j3-u0u5ulmm6k-rpc.us0-aws.kaleido.io
+          NODE_TWO_TESSERA: u0a5aft4j3-u0u5ulmm6k-ptx.us0-aws.kaleido.io
           NODE_TWO_PUB_KEY: Cr4orZhLtEKXSu6XQVvfTDpTUTvXYVnPHuym+r92skk=
           NODE_THREE_HOST: u0a5aft4j3-u0sog5yz3u-rpc.us0-aws.kaleido.io
+          NODE_THREE_TESSERA: u0a5aft4j3-u0sog5yz3u-ptx.us0-aws.kaleido.io
           NODE_THREE_PUB_KEY: MzL4UtMSfRm0dUG+X08cYj39/Sa5QFFBVWuc42YZkwg=
       - name: Make reports/screenshots available
         uses: actions/upload-artifact@v1

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -8,7 +8,7 @@ module.exports = {
   src_folders: ['test-browser/tests'],
 
   // See https://nightwatchjs.org/guide/working-with-page-objects/
-  page_objects_path: '',
+  page_objects_path: ['test-browser/pages'],
 
   output_folder: 'reports',
 

--- a/src/actions/network.js
+++ b/src/actions/network.js
@@ -1,4 +1,10 @@
-import { getAccounts, getTesseraParties, getTesseraKeys, updateWeb3Url, testUrls } from '../api'
+import {
+  getAccounts,
+  updateWeb3Url,
+  testUrls,
+  getPrivateForOptions,
+  getPrivateFromOptions
+} from '../api'
 import { setTesseraParties, setTesseraKeys } from './tessera'
 import { setError } from './error'
 import { resetTransactionResults } from './contracts'
@@ -42,9 +48,9 @@ export function connectToNetwork (endpoint, tesseraEndpoint) {
         editing = false
         accounts = await getAccounts()
         if (tesseraEndpoint !== '') {
-          const parties = await getTesseraParties()
+          const parties = await getPrivateForOptions()
           dispatch(setTesseraParties(parties))
-          const keys = await getTesseraKeys()
+          const keys = await getPrivateFromOptions()
           dispatch(setTesseraKeys(keys))
         } else {
           dispatch(setTesseraParties([]))
@@ -78,11 +84,6 @@ export function connectToNetwork (endpoint, tesseraEndpoint) {
 export function saveNetwork (endpoint = '', tesseraEndpoint = '') {
   return async dispatch => {
     try {
-
-      if (tesseraEndpoint.endsWith('/')) {
-        tesseraEndpoint = tesseraEndpoint.substring(0,
-          tesseraEndpoint.length - 1)
-      }
 
       await testUrls(endpoint, tesseraEndpoint)
       dispatch(connectToNetwork(endpoint, tesseraEndpoint))

--- a/src/actions/txMetadata.js
+++ b/src/actions/txMetadata.js
@@ -5,6 +5,13 @@ export function showTxMetadata (show) {
   }
 }
 
+export function updatePrivateTransaction (isPrivate) {
+  return {
+    type: 'UPDATE_PRIVATE_TRANSACTION',
+    payload: isPrivate
+  }
+}
+
 export function updatePrivateFor (selection) {
   return {
     type: 'UPDATE_PRIVATE_FOR',

--- a/src/components/App.css
+++ b/src/components/App.css
@@ -1,1 +1,3 @@
-
+input.form-control {
+    font-size: 10pt !important;
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -42,7 +42,7 @@ function Footer () {
     <div>
       <a href={"https://medium.com/remix-ide/quorum-plugin-for-remix-ee232ebca64c"} rel="noopener noreferrer" target="_blank">Help</a>
       {' | '}
-      <a href={`https://github.com/jpmorganchase/quorum-remix/tree/${gitHash}`} target="_blank">Version</a>
+      <a href={`https://github.com/jpmorganchase/quorum-remix/tree/${gitHash}`} rel="noopener noreferrer" target="_blank">Version</a>
     </div>
   </div>
 }

--- a/src/components/Constructor.js
+++ b/src/components/Constructor.js
@@ -28,6 +28,7 @@ export const Constructor = ({ method, onDeploy, onExisting, loading }) => {
         At Address
       </button>
       <input placeholder="Existing contract address"
+             className="form-control"
              id="existing-input"
              disabled={loading}
              style={inputStyle}

--- a/src/components/Contract.js
+++ b/src/components/Contract.js
@@ -3,7 +3,6 @@ import { Method } from './Transact'
 import copy from 'copy-to-clipboard'
 import {
   bodyStyle,
-  checkboxLabelStyle,
   contractStyle,
   ellipsisStyle,
   headerStyle,

--- a/src/components/Contract.js
+++ b/src/components/Contract.js
@@ -7,7 +7,8 @@ import {
   contractStyle,
   ellipsisStyle,
   headerStyle,
-  iconStyle
+  iconStyle,
+  smallCheckboxLabelStyle
 } from '../utils/Styles'
 import { useDispatch, useSelector } from 'react-redux'
 import { doMethodCall, expandContract, removeContract } from '../actions'
@@ -61,7 +62,7 @@ export function Contract ({ address }) {
       <div>Private for:</div>
       {selectedPrivateFor.map(
         ({ enabled, key }, index) => (
-          <label key={key} style={checkboxLabelStyle}>
+          <label key={key} style={smallCheckboxLabelStyle}>
             <input type="checkbox" name={key}
                    style={{marginRight: 4}}
                    checked={enabled}

--- a/src/components/Deploy.js
+++ b/src/components/Deploy.js
@@ -20,7 +20,7 @@ export function Deploy() {
     if (!(selectedContract in contracts)) {
       dispatch(selectContract(Object.keys(contracts)[0]))
     }
-  }, [contracts])
+  }, [contracts]) // eslint-disable-line react-hooks/exhaustive-deps
 
 
   return <div style={{ width: '100%' }}>

--- a/src/components/Deploy.js
+++ b/src/components/Deploy.js
@@ -3,6 +3,7 @@ import { Constructor } from './Constructor'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import { addExistingContract, deployContract, selectContract } from '../actions'
 import { getConstructor } from '../utils/ContractUtils'
+import { bootstrapSelectStyle } from '../utils/Styles'
 
 export function Deploy() {
   const txMetadata = useSelector(state => state.txMetadata, shallowEqual)
@@ -22,12 +23,14 @@ export function Deploy() {
   }, [contracts])
 
 
-  return <div style={{width: '100%'}}>
+  return <div style={{ width: '100%' }}>
     <div>Compiled Contracts:</div>
-    <select className="form-control"
-            id="compiled-select"
-            defaultValue={selectedContract}
-            onChange={(e) => dispatch(selectContract(e.target.value))}>
+    <select
+      style={bootstrapSelectStyle}
+      className="form-control custom-select"
+      id="compiled-select"
+      defaultValue={selectedContract}
+      onChange={(e) => dispatch(selectContract(e.target.value))}>
       {Object.entries(contracts).map(
         ([name, data]) => <option key={name} value={name}>{name}</option>)}
     </select>

--- a/src/components/PrivateFrom.js
+++ b/src/components/PrivateFrom.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
 import {
   updatePrivateFrom,
@@ -16,6 +16,14 @@ export function PrivateFrom () {
     useSelector(state => state.tessera.keysFromUser, shallowEqual)
   const keysFromServer =
     useSelector(state => state.tessera.keysFromServer, shallowEqual)
+
+  useEffect(() => {
+    // maybe a better way to do this, but select the first key if unset or
+    // if selected key is no longer in the list of keys from the server
+    if (keysFromServer.length > 0 && !keysFromServer.includes(privateFrom)) {
+      dispatch(updatePrivateFrom(keysFromServer[0]))
+    }
+  }, [keysFromServer]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div>
     <PrivateSelection

--- a/src/components/PrivateSelection.js
+++ b/src/components/PrivateSelection.js
@@ -31,7 +31,7 @@ export function PrivateSelection (props) {
   const Option = (props) => {
     const option = props.data
 
-    return <components.Option {...props}>
+    return <components.Option className="bg-light" {...props}>
       <div style={optionStyle}>
         <div style={optionLabelContainerStyle}>
           <div style={optionLabelStyle}>
@@ -50,7 +50,25 @@ export function PrivateSelection (props) {
 
   return <SelectContainer
     id={props.containerId}
-    components={{ Option }}
+    styles={{
+      option: (provided, state) => ({ ...provided, color: 'inherit' }),
+      input: (provided, state) => ({ ...provided, color: 'inherit', fontSize: '10pt' }),
+      placeholder: (provided, state) => ({ ...provided, fontSize: '10pt' }),
+      singleValue: (provided, state) => ({ ...provided, color: 'inherit', fontSize: '10pt'  }),
+      multiValue: (provided, state) => ({ ...provided, color: 'inherit', fontSize: '10pt'  }),
+      multiValueLabel: (provided, state) => ({ ...provided, color: 'inherit', fontSize: '10pt'  }),
+      noOptionsMessage: (provided, state) => ({ ...provided, color: 'inherit', fontSize: '10pt'  }),
+    }}
+    className={''}
+    components={{
+      Option,
+      Control: (props) => <components.Control {...props} className={'bg-light border-light'}/>,
+      Menu: (props) => <components.Menu {...props} className={'bg-light'}/>,
+      MenuList: (props) => <components.MenuList {...props} className={'bg-light'}/>,
+      NoOptionsMessage: (props) => <components.NoOptionsMessage {...props} className={'bg-light'}/>,
+      MultiValue: (props) => <components.MultiValue {...props} className={'bg-light'}/>,
+      ValueContainer: (props) => <components.ValueContainer {...props} className={'bg-light'}/>,
+    }}
     placeholder="Select or add..."
     options={options}
     value={selectedOptions}

--- a/src/components/PrivateSelection.js
+++ b/src/components/PrivateSelection.js
@@ -40,7 +40,10 @@ export function PrivateSelection (props) {
         </div>
         {option.userCreated &&
         <i style={iconStyle} className="fa fa-close"
-           onClick={() => remove(option.value)}/>
+           onClick={(event) => {
+             event.stopPropagation()
+             remove(option.value)
+           }}/>
         }
       </div>
     </components.Option>

--- a/src/components/Transact.js
+++ b/src/components/Transact.js
@@ -87,6 +87,7 @@ export const Method = ({ method, onSubmit, result, loading }) => {
       </button>
       {hasParams  &&
       <input placeholder={method.inputs.map((input) => `${input.type} ${input.name}`).join(', ')}
+             className="form-control"
              disabled={loading}
              style={inputStyle}
              onChange={(e) => onSingleLineInputChange(e.target.value)}
@@ -141,6 +142,7 @@ export const TransactionInput = ({ input, onChange, value, disabled }) => {
       <div key={`${input.name}${index}`} className="input-group method-inputs"
            data-param={input.name}>
         <input type="text" data-param={input.name}
+               className="form-control"
                data-type={input.type}
                value={value}
                disabled={disabled}

--- a/src/components/TxMetadata.js
+++ b/src/components/TxMetadata.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react'
 import {
   bootstrapSelectStyle,
+  checkboxLabelStyle,
+  checkboxStyle,
   ellipsisStyle,
   formContainerStyle,
   headerStyle,
@@ -19,7 +21,7 @@ import {
   changeValue,
   changeValueDenomination,
   selectAccount,
-  showTxMetadata,
+  showTxMetadata, updatePrivateTransaction,
 } from '../actions'
 import { InputTooltip } from './InputTooltip'
 import { PrivateFor } from './PrivateFor'
@@ -37,6 +39,7 @@ export function TxMetadata () {
       value,
       valueDenomination,
       show,
+      privateTransaction,
     }
   } = state
 
@@ -141,14 +144,18 @@ export function TxMetadata () {
          className="fa fa-clipboard"
          onClick={(e) => copyAddress()}/>
     </div>
-    <div style={txMetaRowStyle}>
-      <div style={labelStyle}>Private for</div>
-      <div style={reactSelectStyle}><PrivateFor/></div>
+    <div id="private-checkbox-row" style={{...txMetaRowStyle, cursor: 'pointer'}} onClick={() => dispatch(updatePrivateTransaction(!privateTransaction))}>
+      <input id="private-checkbox" type="checkbox" style={checkboxStyle} className="form-check" checked={privateTransaction}/>
+      <div style={checkboxLabelStyle}>Private Transaction</div>
     </div>
-    <div style={txMetaRowStyle}>
+    {privateTransaction && (<div style={txMetaRowStyle}>
       <div style={labelStyle}>Private from</div>
       <div style={reactSelectStyle}><PrivateFrom/></div>
-    </div>
+    </div>)}
+    {privateTransaction && (<div style={txMetaRowStyle}>
+      <div style={labelStyle}>Private for</div>
+      <div style={reactSelectStyle}><PrivateFor/></div>
+    </div>)}
     {renderHeader()}
     {show ? expandedMetadata() : collapsedMetadata()}
   </div>

--- a/src/components/TxMetadata.js
+++ b/src/components/TxMetadata.js
@@ -1,14 +1,15 @@
 import React, { useEffect } from 'react'
 import {
+  bootstrapSelectStyle,
   ellipsisStyle,
   formContainerStyle,
   headerStyle,
   iconStyle,
   inlineInputStyle,
   labelStyle,
+  largeInlineInputStyle,
   reactSelectStyle,
   txMetaRowStyle,
-  largeInlineInputStyle,
 } from '../utils/Styles'
 import copy from 'copy-to-clipboard'
 import { useDispatch, useSelector } from 'react-redux'
@@ -126,9 +127,12 @@ export function TxMetadata () {
   return <div style={formContainerStyle}>
     <div style={txMetaRowStyle}>
       <div style={labelStyle}>Account</div>
-      <select className="form-control" defaultValue={account}
-              id="account-select"
-              onChange={(e) => dispatch(selectAccount(e.target.value))}>
+      <select
+        style={bootstrapSelectStyle}
+        className="form-control custom-select"
+        defaultValue={account}
+        id="account-select"
+        onChange={(e) => dispatch(selectAccount(e.target.value))}>
         {accounts.map(
           (account) => <option key={account}
                                value={account}>{account}</option>)}

--- a/src/components/TxMetadata.js
+++ b/src/components/TxMetadata.js
@@ -54,7 +54,7 @@ export function TxMetadata () {
     if (accounts.length > 0 && !accounts.includes(account)) {
       dispatch(selectAccount(accounts[0]))
     }
-  }, [accounts])
+  }, [accounts]) // eslint-disable-line react-hooks/exhaustive-deps
 
   function expandedMetadata () {
     return <>

--- a/src/reducers/txMetadata.js
+++ b/src/reducers/txMetadata.js
@@ -4,6 +4,9 @@ const initialState = {
   value: '0',
   valueDenomination: 'wei',
   show: false,
+  privateTransaction: false,
+  privateFor: undefined,
+  privateFrom: undefined,
 }
 
 export function txMetadataReducer (txMetadata = initialState, action) {
@@ -44,6 +47,12 @@ export function txMetadataReducer (txMetadata = initialState, action) {
         valueDenomination: action.payload
       }
 
+    case 'UPDATE_PRIVATE_TRANSACTION':
+      return {
+        ...txMetadata,
+        privateTransaction: action.payload,
+      }
+
     case 'UPDATE_PRIVATE_FOR':
       // empty [] privateFor is different than undefined. Disallow [] for now
       const privateFor = action.payload && action.payload.length > 0
@@ -53,12 +62,12 @@ export function txMetadataReducer (txMetadata = initialState, action) {
         privateFor,
       }
 
-      case 'UPDATE_PRIVATE_FROM':
-        const privateFrom = action.payload
-        return {
-          ...txMetadata,
-          privateFrom,
-        }
+    case 'UPDATE_PRIVATE_FROM':
+      const privateFrom = action.payload
+      return {
+        ...txMetadata,
+        privateFrom,
+      }
 
     default:
       return txMetadata

--- a/src/utils/Styles.js
+++ b/src/utils/Styles.js
@@ -134,6 +134,17 @@ export const labelStyle = {
   minWidth: 72,
 }
 
+export const checkboxStyle = {
+  marginLeft: 4,
+}
+
+export const checkboxLabelStyle = {
+  fontSize: 12,
+  whiteSpace: 'nowrap',
+  minWidth: 72,
+  padding: 12,
+}
+
 export const smallLabelStyle = {
   whiteSpace: 'nowrap',
   minWidth: 72,
@@ -150,7 +161,7 @@ export const largeInlineInputStyle = {
   marginRight: 4,
 }
 
-export const checkboxLabelStyle = {
+export const smallCheckboxLabelStyle = {
   display: 'block',
   whiteSpace: 'nowrap',
   overflow: 'hidden',

--- a/src/utils/Styles.js
+++ b/src/utils/Styles.js
@@ -42,7 +42,6 @@ export const buttonStyle = {
 
 export const inputStyle = {
   border: '1px solid #dddddd',
-  fontSize: 10,
   padding: '.36em',
   borderRadius: 5,
   borderTopLeftRadius: 0,
@@ -189,6 +188,9 @@ export const errorStyle = {
   width: 0,
   flexGrow: 1,
 }
+export const bootstrapSelectStyle = {
+  paddingRight: '20px !important'
+}
 
 export const reactSelectStyle = {
   width: 0,
@@ -212,7 +214,8 @@ export const optionLabelStyle = {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  color: '#222'
+  color: 'inherit',
+  fontSize: '10pt',
 }
 
 export const statusStyle = (status) => {

--- a/test-browser/commands/clickItemIfExists.js
+++ b/test-browser/commands/clickItemIfExists.js
@@ -1,14 +1,15 @@
 const EventEmitter = require('events')
+const targetOrSelector = require('../helpers/testHelper').targetOrSelector
 
 class clickItemIfExists extends EventEmitter {
-  command (id) {
+  command (target) {
     const self = this
     this.api.execute(function (id) {
       const item = document.querySelector(id)
       if(item) {
         item.click()
       }
-    }, [id], () => self.emit('complete'))
+    }, [targetOrSelector(target)], () => self.emit('complete'))
     return this
   }
 }

--- a/test-browser/commands/scrollInto.js
+++ b/test-browser/commands/scrollInto.js
@@ -1,9 +1,11 @@
 const EventEmitter = require('events')
+const { targetOrSelector } = require('../helpers/testHelper')
 
 class ScrollInto extends EventEmitter {
   command (target) {
     this.api.perform((client, done) => {
-      _scrollInto(this.api, target, () => {
+      let selector = targetOrSelector(target)
+      _scrollInto(this.api, selector, () => {
         done()
         this.emit('complete')
       })

--- a/test-browser/commands/setUpSolidityPlugins.js
+++ b/test-browser/commands/setUpSolidityPlugins.js
@@ -1,0 +1,29 @@
+const EventEmitter = require('events')
+
+class setUpSolidityPlugins extends EventEmitter {
+  command (target) {
+    this.api
+      // remix-alpha and non-ethereum.org sites show a warning dialog, close it if it exists
+      .clickItemIfExists('#modal-footer-ok')
+      .pause(1000)
+      .click('#icon-panel div[plugin="pluginManager"]')
+      .scrollAndClick('#pluginManager article[id="remixPluginManagerListItem_solidity"] button')
+      .pause(1000)
+      .scrollAndClick('#pluginManager article[id="remixPluginManagerListItem_udapp"] button')
+      .scrollAndClick('#pluginManager article[id="remixPluginManagerListItem_solidityStaticAnalysis"] button')
+      .scrollAndClick('#pluginManager article[id="remixPluginManagerListItem_debugger"] button')
+      .clickLaunchIcon('solidity')
+      .pause(500)
+      .clickItemIfExists('#autoCompile')
+      .scrollAndClick('#icon-panel div[plugin="fileExplorers"]')
+      .pause(100)
+      .click('div[key="browser/1_Storage.sol"]')
+      .pause(100)
+      .perform(() => {
+        this.emit('complete')
+      })
+    return this
+  }
+}
+
+module.exports = setUpSolidityPlugins

--- a/test-browser/helpers/testHelper.js
+++ b/test-browser/helpers/testHelper.js
@@ -1,1 +1,4 @@
 // placeholder file
+module.exports.targetOrSelector = function targetOrSelector(target) {
+  return typeof target === 'object' ? target.selector : target
+}

--- a/test-browser/pages/contract.js
+++ b/test-browser/pages/contract.js
@@ -1,0 +1,58 @@
+const elements = {
+  deployedContract: '.deployed-contract',
+  deployedContractExpand: '.deployed-contract .methCaret',
+  deployedContractClose: '.deployed-contract .fa-close',
+  deployedAddress: '.deployed-contract .input-group-text',
+  methodContainerGet: 'div[data-method="retreive"]',
+  getButton: 'div[data-method="retreive"] button',
+  methodContainerSet: 'div[data-method="store"]',
+  setButton: 'div[data-method="store"] button',
+  setInput: 'div[data-method="store"] input',
+}
+
+const commands = [{
+  setInput: function (value) {
+    return this.clearValue('@setInput').setValue('@setInput', value)
+  },
+  get: function () {
+    return this.click('@getButton')
+  },
+  set: function() {
+    return this.click('@setButton')
+  },
+  getAddress: async function () {
+    return new Promise(((resolve, reject) => {
+      this.getText('@deployedAddress', function (result) {
+        resolve(result.value.replace("Storage(", "").replace(")", ""))
+      })
+    }))
+  },
+  toggleExpand: function () {
+    return this.click('@deployedContractExpand')
+  },
+  close: function () {
+    return this.click('@deployedContractClose')
+  },
+  testContractMethods: function (expectedValue, newValue) {
+    this
+      .toggleExpand()
+      .get()
+      .expect.element('@methodContainerGet').text.to.contain(expectedValue).before(5000)
+
+    this
+      .setInput(newValue)
+      .set()
+      .expect.element('@methodContainerSet').text.to.contain('Success').before(5000)
+
+    this.get()
+      .expect.element('@methodContainerGet').text.to.contain(newValue).before(5000)
+
+    this.close()
+      .expect.element('@deployedContract').to.not.be.present.before(5000)
+  }
+}]
+
+module.exports = {
+  commands,
+  elements,
+}

--- a/test-browser/pages/deploy.js
+++ b/test-browser/pages/deploy.js
@@ -1,0 +1,25 @@
+const elements = {
+  deployButton: {
+    selector: '//button[contains(text(),"Deploy")]',
+    locateStrategy: 'xpath',
+  },
+  existingInput: '#existing-input',
+  existingButton: '#existing-button',
+}
+
+const commands = [{
+  deploy: function () {
+    return this.click('@deployButton')
+  },
+  setAddress: function (address) {
+    return this.clearValue('@existingInput').setValue('@existingInput', address)
+  },
+  attach: function () {
+    return this.click('@existingButton')
+  }
+}]
+
+module.exports = {
+  commands,
+  elements,
+}

--- a/test-browser/pages/metadata.js
+++ b/test-browser/pages/metadata.js
@@ -1,0 +1,26 @@
+const elements = {
+  metadataHeader: '#metadata-header',
+  metadataCollapsed: '#metadata-collapsed',
+  gasPriceInput: '#gas-price-input',
+  gasLimitInput: '#gas-limit-input',
+  valueInput: '#value-input',
+  valueDenomination: '#value-denomination-select',
+}
+
+const commands = [{
+  toggleMetadata: function () {
+    return this.click('@metadataHeader')
+  },
+  setGasLimit: function (value) {
+    if(value === '') {
+      // clearing/setting to empty string doesn't trigger onChange, type a space, then backspace
+      value = [' ', '\uE003']
+    }
+    return this.clearValue('@gasLimitInput').setValue('@gasLimitInput', value)
+  },
+}]
+
+module.exports = {
+  commands,
+  elements,
+}

--- a/test-browser/pages/metadata.js
+++ b/test-browser/pages/metadata.js
@@ -12,11 +12,16 @@ const commands = [{
     return this.click('@metadataHeader')
   },
   setGasLimit: function (value) {
+    this.clearValue('@gasLimitInput')
     if(value === '') {
       // clearing/setting to empty string doesn't trigger onChange, type a space, then backspace
-      value = [' ', '\uE003']
+      this.setValue('@gasLimitInput', ' ')
+      this.api.pause(100)
+      this.sendKeys('@gasLimitInput', '\uE003')
+
+    } else {
+      this.setValue('@gasLimitInput', value)
     }
-    return this.clearValue('@gasLimitInput').setValue('@gasLimitInput', value)
   },
 }]
 

--- a/test-browser/pages/network.js
+++ b/test-browser/pages/network.js
@@ -1,0 +1,28 @@
+const elements = {
+  quorumRpc: '#geth-endpoint',
+  tesseraEndpoint: '#tessera-endpoint',
+  edit: '#network-form .fa-pencil',
+  save: '#network-form .fa-check',
+  status: '#connection-status',
+}
+
+const commands = [{
+  setQuorumEndpoint: function (url) {
+    this.clearValue('@quorumRpc')
+    return this.setValue('@quorumRpc', url)
+  },
+  setTesseraEndpoint: function (url) {
+    return this.clearValue('@tesseraEndpoint').setValue('@tesseraEndpoint', url)
+  },
+  save: function () {
+    return this.click('@save')
+  },
+  edit: function () {
+    return this.click('@edit')
+  }
+}]
+
+module.exports = {
+  commands,
+  elements,
+}

--- a/test-browser/pages/privacy.js
+++ b/test-browser/pages/privacy.js
@@ -1,0 +1,74 @@
+const elements = {
+  privateTransaction: '#private-checkbox-row',
+  privateForSelect: '#private-for-select',
+  privateForInput: '#private-for-select input',
+  privateForDropdown: '#private-for-select div[class*="indicatorContainer"]:last-of-type',
+  privateForMenu: '#private-for-select div[class*="menu"]',
+  privateForFirstBubble: '#private-for-select div[class*="multiValue"]:nth-child(1) div:nth-child(2)',
+  privateForOption: '#private-for-select div[class*="option"]',
+  privateForOptionDelete: '#private-for-select div[class*="option"] .fa-close',
+  privateFromSelect: '#private-from-select',
+  privateFromInput: '#private-from-select input',
+  privateFromDropdown: '#private-from-select div[class*="indicatorContainer"]:last-of-type',
+  privateFromMenu: '#private-from-select div[class*="menu"]',
+  privateFromFirstBubble: '#private-from-select div[class*="multiValue"]:nth-child(1) div:nth-child(2)',
+  privateFromOption: '#private-from-select div[class*="option"]',
+  privateFromOptionDelete: '#private-from-select div[class*="option"] .fa-close',
+}
+
+const commands = [{
+  togglePrivate: function () {
+    return this.click('@privateTransaction')
+  },
+  addPrivateForKey: function (key) {
+    return this.setValue('@privateForInput', key)
+      .sendKeys('@privateForInput', this.api.Keys.ENTER)
+  },
+  togglePrivateForMenu: function () {
+    this.click('@privateForDropdown')
+    this.api.pause(100)
+    return this
+  },
+  selectPrivateForOption: function (key) {
+    this.api
+      .useXpath()
+      .click(`//*[@id='private-for-select']//div[contains(text(), '${key}')]`)
+      .useCss()
+      .pause(100)
+    return this
+  },
+  closeFirstPrivateForBubble: function () {
+    this.click('@privateForFirstBubble')
+    this.api.pause(100)
+    return this
+  },
+  deleteFirstPrivateForOption: function () {
+    this.click('@privateForOptionDelete')
+    this.api.pause(100)
+    return this
+  },
+  addPrivateFromKey: function (key) {
+    return this.setValue('@privateFromInput', key)
+      .sendKeys('@privateFromInput', this.api.Keys.ENTER)
+  },
+  togglePrivateFromMenu: function () {
+    this.click('@privateFromDropdown')
+    this.api.pause(100)
+    return this
+  },
+  closeFirstPrivateFromBubble: function () {
+    this.click('@privateFromFirstBubble')
+    this.api.pause(100)
+    return this
+  },
+  deleteFirstPrivateFromOption: function () {
+    this.click('@privateFromOptionDelete')
+    this.api.pause(100)
+    return this
+  },
+}]
+
+module.exports = {
+  commands,
+  elements,
+}

--- a/test-browser/pages/remix.js
+++ b/test-browser/pages/remix.js
@@ -1,0 +1,37 @@
+const elements = {
+  pluginManager: '#icon-panel div[plugin="pluginManager"]',
+  activateQuorum: '#pluginManager article[id="remixPluginManagerListItem_quorum"] button',
+  remember: '#remember',
+  permissionOk: '#modal-footer-ok',
+  footer: '#footer',
+}
+
+const commands = [{
+  activateQuorumPlugin: function () {
+    return this
+      .click('@pluginManager')
+      .scrollAndClick('@activateQuorum')
+    // permission dialog
+  },
+  acceptPermissions: function () {
+    this.api.pause(1000)
+    this.clickItemIfExists('@remember')
+    this.api.pause(500)
+    return this.clickItemIfExists('@permissionOk')
+      .clickLaunchIcon('quorum')
+  },
+  switchToPluginFrame: function () {
+    // this will switch to the iframe for the remaining tests
+    // workaround for firefox (.frame('id') wasn't working)
+    this.api.element('css selector', '#plugins div iframe', (frame) => {
+      this.api.frame(frame.value)
+    })
+      .waitForElementVisible('.App', 5000)
+    return this
+  },
+}]
+
+module.exports = {
+  commands,
+  elements,
+}


### PR DESCRIPTION
Sorry, this PR got pretty big:

- Adds private checkbox to distinguish between public, private with no keys selected, and private with keys selected
- Hides privateFor and privateFrom when not checked
- Selects first privateFrom option automatically when received from server
- Refactors Tessera request code to work with basic auth, reuse code
- Uses nightwatch page objects to organize tests and make them more readable
- Fixes bug where removing a privateFor option would also select it