### PR TITLE
Specifies nightwatch version 1.3.2 because of bugs in 1.3.4, updates …

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     ]
   },
   "devDependencies": {
-    "chromedriver": "^79.0.0",
+    "chromedriver": "^80.0.0",
     "geckodriver": "^1.19.1",
-    "nightwatch": "^1.3.2",
+    "nightwatch": "1.3.2",
     "selenium-server": "^3.141.59"
   }
 }


### PR DESCRIPTION
…chromedriver version to match github actions